### PR TITLE
feat(parse): add extraCompositions child node titles

### DIFF
--- a/.changeset/fast-owls-compete.md
+++ b/.changeset/fast-owls-compete.md
@@ -1,0 +1,5 @@
+---
+"@lottiefiles/relottie-parse": patch
+---
+
+feat: add extraCompositions child node titles

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: Release
-
+    if: ${{ github.repository == 'LottieFiles/relottie' && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -29,6 +29,8 @@ jobs:
         with:
           cache: 'pnpm'
           node-version: ${{ matrix.node-version }}
+          scope: '@lottiefiles'
+          registry-url: 'https://npm.pkg.github.com/'
 
       - name: 📥 Install dependencies
         run: pnpm install

--- a/packages/relottie-parse/src/entities.ts
+++ b/packages/relottie-parse/src/entities.ts
@@ -834,6 +834,9 @@ export const objectEntity: NoKeyEntityMap = {
   [CT.textRanges]: {
     defaultTitle: OT.textRange,
   },
+  [CT.extraCompositions]: {
+    defaultTitle: OT.assetPrecomposition,
+  },
 };
 
 const createDependentTitles = (

--- a/packages/relottie-parse/src/parse.ts
+++ b/packages/relottie-parse/src/parse.ts
@@ -2,7 +2,7 @@
  * Copyright 2022 Design Barn Inc.
  */
 
-import { parse as jsonParse, traverse as jsontraverse } from '@humanwhocodes/momoa';
+import { parse as jsonParse, traverse as jsonTraverse } from '@humanwhocodes/momoa';
 import type {
   ArrayNode,
   Collection,
@@ -538,7 +538,7 @@ export function parse(document: string, file: VFile, settings: SettingsOptions =
 
   const info: Info = { hasExpressions: false };
 
-  jsontraverse(jsonAst, {
+  jsonTraverse(jsonAst, {
     enter(node: Momoa.AstNode, parent: Momoa.AstParent) {
       traverseJsonEnter(node, parent, lastStack, file, options);
     },


### PR DESCRIPTION
## Description

The "Extra Compositions" (comps) children nodes have to be "asset Precompositions".
More details at https://lottiefiles.github.io/lottie-docs/schema/#/$defs/assets/precomposition

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] This is something we need to do.
