### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
   validate:
     name: Validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         node-version: ['20']


### PR DESCRIPTION
Potential fix for [https://github.com/LottieFiles/relottie/security/code-scanning/1](https://github.com/LottieFiles/relottie/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `validate` job. Since the job only performs read-only operations (e.g., installing dependencies, building, linting, and testing), it should only require `contents: read` permissions. This change will restrict the job's access to the repository contents without granting unnecessary write permissions.

The `permissions` block will be added directly under the `validate` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
